### PR TITLE
Add Omeka 4 to contraints

### DIFF
--- a/config/module.ini
+++ b/config/module.ini
@@ -1,7 +1,7 @@
 [info]
 name    = "Fields as Tags"
 version = "1.0.1"
-omeka_version_constraint = "^2.0.0 || ^3.0.0"
+omeka_version_constraint = "^2.0.0 || ^3.0.0 || ^4.0.0"
 description  = "Shows browsable tags based in metadata fields in Omeka S item lists"
 tags         = "web, tags, metadata, browse, navigation"
 license      = "MIT"


### PR DESCRIPTION
Adds Omeka 4.0.0 to the list of Omeka versions (`omeka_version_constraint`).